### PR TITLE
- git epoch starts later than 01/01/1970

### DIFF
--- a/examples/sccs2git-add
+++ b/examples/sccs2git-add
@@ -54,6 +54,16 @@ foreach my $c (sort keys %sccs) {
 
     system "git", "add", $fn;
 
+    #
+    # Advance earlier epoch timestamp to git epoch timestamp.
+    # git considers anything with timestamp earlier
+    # than 100000000 since epoch as invalid timestamp.
+    #
+    if ($delta{stamp} < 100000000) {
+	$delta{stamp} = $delta{stamp} + 1;
+	$stamp = pr_date ($delta{stamp} + 1);
+    }
+
     # Do the git actions to put this file in git ...
     my $mr   = $delta{mr} || ""; $mr =~ s/^-$//;
     my $cmnt = $delta{comment} || "";

--- a/examples/sccs2git-gfi
+++ b/examples/sccs2git-gfi
@@ -78,6 +78,14 @@ foreach my $c (sort keys %sccs) {
     printf STDERR "%-20s %3d %6s  %s %s %s\n", $fn, $rev, $vsn,
 	$stamp, $delta{date}, $delta{"time"};
 
+    #
+    # Advance earlier epoch timestamp to git epoch timestamp.
+    # git considers anything with timestamp earlier
+    # than 100000000 since epoch as invalid timestamp.
+    #
+    if ($delta{stamp} < 100000000) {
+	$delta{stamp} = $delta{stamp} + 1;
+    }
     print { $gfi } "commit ", $branchname, "\n";
     print { $gfi } "committer ", $delta{committer}, " <",
 	    ($delta{committer}, "@", $domain, "> ", $delta{stamp},

--- a/examples/sccs2git-r
+++ b/examples/sccs2git-r
@@ -93,6 +93,14 @@ foreach my $c (sort keys %sccs) {
     printf STDERR "%-20s %3d %6s  %s %s %s\n", $fn, $rev, $vsn,
 	$stamp, $delta{date}, $delta{"time"};
 
+    #
+    # Advance earlier epoch timestamp to git epoch timestamp.
+    # git considers anything with timestamp earlier
+    # than 100000000 since epoch as invalid timestamp.
+    #
+    if ($delta{stamp} < 100000000) {
+	$delta{stamp} = $delta{stamp} + 1;
+    }
     print { $gfi } "commit ", $branchname, "\n";
     print { $gfi } "committer ", $delta{committer},
 	" <", $delta{committer}, "@", $domain, "> ",


### PR DESCRIPTION
While converting pretty old repo I hit issue as follows:
```
Makefile.master        1    1.1  Thu 01-01-1970 00:00:00 70/01/01 00:00:00
Makefile.master        2    1.2  Thu 01-01-1970 00:00:01 70/01/01 00:00:01
Makefile.lint          2    1.2  Thu 01-01-1970 00:00:02 70/01/01 00:00:02
fatal: Invalid raw date "0 but true +0000" in ident: Fake <Fake@ST037> 0 but true +0000
Makefile               1    1.1  Mon 26-06-1989 20:35:22 89/06/26 20:35:22
Makefile               2    1.2  Mon 26-06-1989 20:35:23 89/06/26 20:35:23
...
fast-import: dumping crash report to .git/fast_import_crash_28322
Makefile.master        8    1.5  Mon 13-11-1989 12:59:01 89/11/13 12:59:01
Makefile.master        9    1.6  Tue 14-11-1989 20:36:37 89/11/14 20:36:37
```
doing some gooling I've learned git considers anything before `Saturday, March 3, 1973 9:46:40 AM` (100 000 000 Secs) as an invalid timestamp. More information can be found [here](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=625480)

this naive fix makes tool working for me.

I'm filing this pull request just for the record.